### PR TITLE
meta: Rename repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ KBSecret
 ========
 
 [![Gem Version](https://badge.fury.io/rb/kbsecret.svg)](https://badge.fury.io/rb/kbsecret)
-[![Build Status](https://travis-ci.org/woodruffw/kbsecret.svg?branch=master)](https://travis-ci.org/woodruffw/kbsecret)
-[![Coverage Status](https://coveralls.io/repos/github/woodruffw/kbsecret/badge.svg?branch=coveralls)](https://coveralls.io/github/woodruffw/kbsecret?branch=coveralls)
+[![Build Status](https://travis-ci.org/kbsecret/kbsecret.svg?branch=master)](https://travis-ci.org/kbsecret/kbsecret)
+[![Coverage Status](https://coveralls.io/repos/github/kbsecret/kbsecret/badge.svg?branch=coveralls)](https://coveralls.io/github/kbsecret/kbsecret?branch=coveralls)
 
 *Note*: This is still a work in process. Use it with caution.
 
@@ -35,7 +35,7 @@ $ gem install --pre kbsecret
 For hacking:
 
 ```bash
-$ git clone git@github.com:woodruffw/kbsecret.git && cd kbsecret
+$ git clone git@github.com:kbsecret/kbsecret.git && cd kbsecret
 $ bundle install --path vendor/bundle
 $ RUBYLIB=./lib PATH=./bin:${PATH} bundle exec ./bin/kbsecret help
 ```
@@ -120,8 +120,8 @@ Please feel free to contribute completion scripts for other shells!
 
 ### Contributing
 
-See ["help wanted"](https://github.com/woodruffw/kbsecret/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-on the [issue tracker](https://github.com/woodruffw/kbsecret/issues).
+See ["help wanted"](https://github.com/kbsecret/kbsecret/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+on the [issue tracker](https://github.com/kbsecret/kbsecret/issues).
 
 If you have an idea for a new feature, please suggest it! Pull requests are also welcome.
 

--- a/kbsecret.gemspec
+++ b/kbsecret.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files                 = Dir["LICENSE", "*.md", ".yardopts", "lib/**/*"]
   s.executables           = Dir["bin/*"].map { |p| File.basename(p) }
   s.required_ruby_version = ">= 2.3.0"
-  s.homepage              = "https://github.com/woodruffw/kbsecret"
+  s.homepage              = "https://github.com/kbsecret/kbsecret"
   s.license               = "MIT"
 
   # these need to be installed by developers alone

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 
 module KBSecret
   # kbsecret's current version
-  VERSION = "0.9.0.pre.1"
+  VERSION = "0.9.0.pre.2"
 end

--- a/man/kbsecret.1.ronnpp
+++ b/man/kbsecret.1.ronnpp
@@ -114,7 +114,7 @@ and secret managers, but is worth remembering.
 `kbsecret` is licensed under the terms of the MIT license.
 
 The full text can be found under the "LICENSE" file in `kbsecret`'s source code,
-which is available at {https://github.com/woodruffw/kbsecret}.
+which is available at {https://github.com/kbsecret/kbsecret}.
 
 ## LINKS
 


### PR DESCRIPTION
The repository is now at kbsecret/kbsecret, so these links
were updated.
