### PR TITLE
Session path refactoring

### DIFF
--- a/lib/kbsecret/cli/kbsecret-sessions
+++ b/lib/kbsecret/cli/kbsecret-sessions
@@ -26,6 +26,6 @@ Config.session_labels.each do |sess_name|
 
   puts <<~EOS
     \tUsers: #{session_hash[:users].join(", ")}
-    \tSecrets root: #{session_hash[:root]} (#{session.directory})
+    \tSecrets root: #{session_hash[:root]} (#{session.path})
   EOS
 end

--- a/lib/kbsecret/record/abstract.rb
+++ b/lib/kbsecret/record/abstract.rb
@@ -127,7 +127,7 @@ module KBSecret
         @label      = label.to_s
         @type       = self.class.type
         @data       = { @type => body }
-        @path       = File.join(session.directory, "#{label}.json")
+        @path       = File.join(session.path, "#{label}.json")
         @defer_sync = false
 
         populate_internal_fields
@@ -142,7 +142,7 @@ module KBSecret
         @label      = hsh[:label]
         @type       = hsh[:type].to_sym
         @data       = hsh[:data]
-        @path       = File.join(session.directory, "#{label}.json")
+        @path       = File.join(session.path, "#{label}.json")
         @defer_sync = false
       end
 

--- a/lib/kbsecret/session.rb
+++ b/lib/kbsecret/session.rb
@@ -14,7 +14,7 @@ module KBSecret
     attr_reader :config
 
     # @return [String] the fully-qualified path of the session
-    attr_reader :directory
+    attr_reader :path
 
     # @param label [String, Symbol] the label of the session to initialize
     # @raise [Exceptions::SessionLoadError] if the session has no users or any invalid Keybase users
@@ -27,7 +27,7 @@ module KBSecret
 
       raise Exceptions::SessionLoadError, "no users in session" if @config[:users].empty?
 
-      @directory = rel_path mkdir: true
+      @path = rel_path mkdir: true
       @records   = load_records!
     end
 
@@ -98,16 +98,16 @@ module KBSecret
 
     # Delete the entire session.
     # @return [void]
-    # @note Use this with caution, as *all* files under the session directory
-    #   will be deleted. Furthermore, the session directory itself will
+    # @note Use this with caution, as *all* files under the session path
+    #   will be deleted. Furthermore, the session path itself will
     #   be deleted, and this object will become garbage.
     def unlink!
-      FileUtils.rm_rf(directory)
+      FileUtils.rm_rf(path)
     end
 
     # @return [Array<String>] the fully qualified paths of all records in the session
     def record_paths
-      Dir[File.join(directory, "*.json")]
+      Dir[File.join(path, "*.json")]
     end
 
     # Load all records associated with the session.
@@ -119,7 +119,7 @@ module KBSecret
       end
     end
 
-    # @param mkdir [Boolean] whether or not to make the session directory
+    # @param mkdir [Boolean] whether or not to make the session path
     # @return [String] the fully qualified path to the session
     # @api private
     def rel_path(mkdir: false)

--- a/test/test_sessions.rb
+++ b/test/test_sessions.rb
@@ -96,7 +96,7 @@ class KBSecretSessionsTest < Minitest::Test
     sess = KBSecret::Session.new label: label
 
     # create an empty JSON file, which won't parse correctly
-    bad = File.join(sess.directory, "foo.json")
+    bad = File.join(sess.path, "foo.json")
     FileUtils.touch bad
 
     # attempting to load the session now should fail


### PR DESCRIPTION
This makes the `Session` class more consistent with `Record::Abstract`
and its implementations, which all contain the `#path` method.

It also better reflects the fact that `Session` instances keep
track of their absolute (fully-qualified) paths, not their
relative directories.