### PR TITLE
Place KBFS mountpoint in configuration

### DIFF
--- a/lib/kbsecret.rb
+++ b/lib/kbsecret.rb
@@ -14,5 +14,5 @@ require_relative "kbsecret/cli"
 module KBSecret
   # fail very early if the user doesn't have keybase and KBFS running
   raise Keybase::Exceptions::KeybaseNotRunningError unless Keybase.running?
-  raise Keybase::Exceptions::KBFSNotRunningError unless Dir.exist?(Keybase::Config::KBFS_MOUNT)
+  raise Keybase::Exceptions::KBFSNotRunningError unless Dir.exist?(Config[:mount])
 end

--- a/lib/kbsecret/config.rb
+++ b/lib/kbsecret/config.rb
@@ -57,6 +57,7 @@ module KBSecret
     # configuration defaults
     # @api private
     DEFAULT_CONFIG = {
+      mount: "/keybase",
       sessions: DEFAULT_SESSION.dup,
       generators: DEFAULT_GENERATOR.dup,
     }.freeze

--- a/lib/kbsecret/session.rb
+++ b/lib/kbsecret/session.rb
@@ -124,7 +124,7 @@ module KBSecret
     # @api private
     def rel_path(mkdir: false)
       # /keybase/private/[u1,u2,...,uN]/kbsecret/[session]
-      path = File.join(Keybase::Config::KBFS_MOUNT, "private",
+      path = File.join(Config[:mount], "private",
                        Keybase::U[@config[:users]],
                        "kbsecret", @config[:root])
 

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -8,11 +8,23 @@ elsif ENV["COVERALLS"]
   Coveralls.wear!
 end
 
+require "yaml"
+require "tmpdir"
 require "fileutils"
 require "securerandom"
 require "minitest/autorun"
 
 if ENV["TEST_NO_KEYBASE"]
+  # back up the user's config, if it exists, so that we don't clobber it during testing
+  conf_path = File.expand_path "~/.config/kbsecret/"
+  FileUtils.mkdir_p conf_path
+
+  conf_file = File.join conf_path, "config.yml"
+  FileUtils.mv conf_file, "#{conf_file}.bak", force: true if File.file?(conf_file)
+
+  dummy_config = { mount: Dir.mktmpdir }
+  File.write conf_file, dummy_config.to_yaml
+
   require_relative "stub/keybase"
   require "keybase/api"
   require "kbsecret/exceptions"
@@ -23,9 +35,12 @@ if ENV["TEST_NO_KEYBASE"]
   require "kbsecret/cli"
 
   MiniTest.after_run do
-    mnt = Keybase::Config::KBFS_MOUNT
+    mnt = KBSecret::Config[:mount]
     # just to be extra certain we don't nuke the real KBFS
     FileUtils.rm_rf mnt unless mnt.start_with?("/keybase")
+
+    # restore the original config, if one exists
+    FileUtils.mv "#{conf_file}.bak", conf_file, force: true if File.file?("#{conf_file}.bak")
   end
 else
   require "keybase"

--- a/test/stub/keybase.rb
+++ b/test/stub/keybase.rb
@@ -1,10 +1,6 @@
 require "tmpdir"
 
 module Keybase
-  module Config
-    KBFS_MOUNT = Dir.mktmpdir
-  end
-
   def self.current_user
     "dummy"
   end


### PR DESCRIPTION
This brings back some early KBSecret behavior, allowing the user
to modify the location that KBSecret looks at for a KBFS mountpoint.

Mounting KBFS anywhere other than `/keybase` still isn't recommended,
but doing this makes testing a little bit easier.
