### PR TITLE
Added zsh completion support (contributes to #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ $ cp man/*.1 ${YOUR_MAN_DIR}
 
 ### Shell Completion
 
-KBSecret provides shell completion functions for bash.
+KBSecret provides shell completion functions for bash and zsh.
 
-To generate them:
+To generate the completions for Bash:
 
 ```bash
 $ bundle exec make bash
@@ -60,6 +60,8 @@ $ # or, if you have additional commands that support --introspect-flags:
 $ CMDS='foo bar baz' bundle exec make bash
 $ cp completions/kbsecret.bash ${YOUR_COMPLETION_DIR}
 ```
+
+To use the completions for zsh, add the completions directory to your $fpath or copy the \_kbsecret file to any of the directories in it.
 
 Please feel free to contribute completion scripts for other shells!
 

--- a/completions/_kbsecret
+++ b/completions/_kbsecret
@@ -1,0 +1,82 @@
+#compdef kbsecret
+
+typeset -A opt_args
+
+_arguments -C \
+  '1:cmd:->cmds' \
+  '*:: :->args' \
+&& ret=0
+
+case "$state" in
+  cmds)
+    # All the commands and its descriptions
+     local actions; actions=(
+      'commands:list available commands'
+      'conf:open configuration in an editor'
+      'dump-fields:dump the fields of a record'
+      'env:access environment records'
+      'generator:manage generators'
+      'generators:list generators'
+      'help:print command-line help'
+      'list:list records'
+      'login:access login records'
+      'new-session:create a new session'
+      'new:create a new record'
+      'pass:retrieve password from a login record'
+      'raw-edit:edit the JSON of a record'
+      'rm-session:desconfigure and delete a session'
+      'rm:remove a record'
+      'sessions:list sessions'
+      'stash-file:store a file in a record'
+      'todo:control to-do records'
+      'types:list known record types'
+      'version:display version information'
+      '-v:display version information'
+      '--version:display version information'
+      '--help:print command-line help'
+      '-h:print command-line help'
+     )
+
+      _describe -t actions 'action' actions && ret=0
+  ;;
+  args)
+    case $line[1] in
+      # Command help works on other commands
+      (--help|-h|help)
+        local flags
+        flags=( $(kbsecret commands) )
+        _describe -t flags 'flag' flags && ret=0
+      ;;
+      # Commands that don't accept --introspect-flag
+      (--version|-v|commands|conf|help|types|version)
+      ;;
+      *)
+        local flags
+        flags=( $(kbsecret $line[1] --introspect-flags) )
+        # Commands with additional completable arguments
+        case $line[1] in
+          new)        flags+=($(kbsecret types)) ;;
+          login|pass) flags+=($(kbsecret list -t login)) ;;
+          env)        flags+=($(kbsecret list -t env)) ;;
+          todo)       flags+=($(kbsecret list -t todo)) ;;
+          *)          flags+=($(kbsecret list)) ;;
+        esac
+        # Additional values for some flags
+        case ${line[CURRENT-1]} in
+          (-s|--session)
+            _values -S , 'sessions' $(kbsecret sessions) && ret=0
+          ;;
+          (-t|--type)
+            _values -S , 'types' $(kbsecret types) && ret=0
+          ;;
+          (-g|--generator)
+            _values -S , 'generators' $(kbsecret generators) && ret=0
+          ;;
+        esac
+        _describe -t flags 'flag' flags && ret=0
+      ;;
+    esac
+  ;;
+esac
+
+return 1


### PR DESCRIPTION
This PR adds a zsh completion file. The README has been updated with instructions to use it. I've tried to format the script as clearly as possible in order to make it easier for anyone to add new commands/options when needed.

It uses the existing bash completion file as a guideline and should behave similarly, using the `--introspect-flags` when available. However, unlike the bash completion, it's not using `kbsecret list` as a default to fill arguments.

Some screenies of the completion working:

![2017-10-01-19 02 53](https://user-images.githubusercontent.com/1296511/31057075-e8d6c48c-a6dc-11e7-8a03-b82f6f99f6dc.png)
![2017-10-01-19 04 04](https://user-images.githubusercontent.com/1296511/31057077-f145ca1e-a6dc-11e7-9b22-530f41fc3b2e.png)
