### PR TITLE
Simple env vars

### DIFF
--- a/lib/kbsecret/cli/kbsecret-env
+++ b/lib/kbsecret/cli/kbsecret-env
@@ -15,7 +15,7 @@ cmd = CLI.create do |c|
     o.string "-s", "--session", "the session to search in", default: :default
     o.bool "-a", "--all", "retrieve all environment records, not just listed ones"
     o.bool "-v", "--value-only", "print only the environment value, not the key"
-    o.bool "-p", "--pairs", "print only VAR=val keypairs without `export`"
+    o.bool "-n", "--no-export", "print only VAR=val keypairs without `export`"
   end
 
   unless c.opts.all?
@@ -40,7 +40,7 @@ selected_records = if cmd.opts.all?
 selected_records.each do |record|
   if cmd.opts.value_only?
     puts record.value
-  elsif cmd.opts.pairs?
+  elsif cmd.opts.no_export?
     puts record.to_assignment
   else
     puts record.to_export

--- a/lib/kbsecret/cli/kbsecret-env
+++ b/lib/kbsecret/cli/kbsecret-env
@@ -15,6 +15,7 @@ cmd = CLI.create do |c|
     o.string "-s", "--session", "the session to search in", default: :default
     o.bool "-a", "--all", "retrieve all environment records, not just listed ones"
     o.bool "-v", "--value-only", "print only the environment value, not the key"
+    o.bool "-p", "--pairs", "print only VAR=val keypairs without `export`"
   end
 
   unless c.opts.all?
@@ -39,6 +40,8 @@ selected_records = if cmd.opts.all?
 selected_records.each do |record|
   if cmd.opts.value_only?
     puts record.value
+  elsif cmd.opts.pairs?
+    puts record.to_assignment
   else
     puts record.to_export
   end

--- a/man/man1/kbsecret-env.1.ronnpp
+++ b/man/man1/kbsecret-env.1.ronnpp
@@ -22,20 +22,26 @@ loading important environment keys into a program without exposing them directly
 	Retrieve all environment records, instead of specifying them on the command-line.
 
 * `-v`, `--value-only`:
-	Print only the value for each environment record, instead of the *KEY=VALUE* format.
+	Print only the value for each environment record, instead of the *export KEY=VALUE* format.
+
+* `-p`, `--pairs`:
+	Print only key/value pairs of the form *KEY=value*, instead of the *export KEY=VALUE* format.
 
 ## EXAMPLES
 
 ```
 	$ kbsecret env -s dev-team foo-api
-	FOO_API=0xDEADBEEF
+	export FOO_API=0xDEADBEEF
 
 	$ kbsecret env -a
-	BAR_API=0xFEEDFACE
-	BAZ_API=thisapiusesapassword
+	export BAR_API=0xFEEDFACE
+	export BAZ_API=thisapiusesapassword
 
 	$ kbsecret env -v baz-api
 	thisapiusesapassword
+
+	$ kbsecret env -p baz-api
+	BAZ_API=thisapiusesapassword
 ```
 
 ## SEE ALSO

--- a/man/man1/kbsecret-env.1.ronnpp
+++ b/man/man1/kbsecret-env.1.ronnpp
@@ -24,7 +24,7 @@ loading important environment keys into a program without exposing them directly
 * `-v`, `--value-only`:
 	Print only the value for each environment record, instead of the *export KEY=VALUE* format.
 
-* `-p`, `--pairs`:
+* `-n`, `--no-export`:
 	Print only key/value pairs of the form *KEY=value*, instead of the *export KEY=VALUE* format.
 
 ## EXAMPLES
@@ -40,7 +40,7 @@ loading important environment keys into a program without exposing them directly
 	$ kbsecret env -v baz-api
 	thisapiusesapassword
 
-	$ kbsecret env -p baz-api
+	$ kbsecret env -n baz-api
 	BAZ_API=thisapiusesapassword
 ```
 


### PR DESCRIPTION
Thank you for contributing to KBSecret! Please fill out the items below to help us merge
your work more quickly.

- [x] Have you run `make test` locally and ensured that all tests pass?
- [x] Have you run `make coverage` locally and ensured that coverage did not drop?

*If* you're changing something in the CLI:
- [x] Have you updated the manual pages and shell completion (if necessary)?

I don't know if `pairs` is my favorite nomenclature for this output format, but I'm open to calling it whatever works best.

Also note that:
1. Tests are failing after the fix of kbsecret/keybase-unofficial-local#1, which I'll look at.
2. The man pages were out-of-date (missing the fact that `export VAR=val` is the default format), so I've updated that as well.

Resolves #24 
