### PR TITLE
new-session with explicit session label

### DIFF
--- a/lib/kbsecret/cli/kbsecret-new-session
+++ b/lib/kbsecret/cli/kbsecret-new-session
@@ -10,19 +10,22 @@ cmd = CLI.create do |c|
   c.slop do |o|
     o.banner = <<~HELP
       Usage:
-        kbsecret new-session [options]
+        kbsecret new-session [options] <label>
     HELP
 
     o.string "-t", "--team", "the team to create the session under"
-    o.string "-l", "--label", "the session label", required: true
     o.array "-u", "--users", "the keybase users", default: [Keybase::Local.current_user]
     o.string "-r", "--root", "the secret root directory"
     o.bool "-f", "--force", "force creation (ignore overwrites, etc.)"
     o.bool "-n", "--no-notify", "do not send a notification to session members"
   end
+
+  c.dreck do
+    string :label
+  end
 end
 
-session_label = cmd.opts[:label]
+session_label = cmd.args[:label]
 
 if Config.session?(session_label) && !cmd.opts.force?
   cmd.die "Refusing to overwrite an existing session without --force."
@@ -59,7 +62,7 @@ else
       To access this session, please run the following:
 
       ```
-        $ kbsecret new-session -l '<your label>' -r '#{cmd.opts[:root]}' -u #{users}
+        $ kbsecret new-session -r '#{cmd.opts[:root]}' -u #{users} <label>
       ```
 
       If you don't have KBSecret installed, you can install it from `gem`:

--- a/lib/kbsecret/cli/kbsecret-new-session
+++ b/lib/kbsecret/cli/kbsecret-new-session
@@ -10,7 +10,7 @@ cmd = CLI.create do |c|
   c.slop do |o|
     o.banner = <<~HELP
       Usage:
-        kbsecret new-session [options] <label>
+        kbsecret new-session <label> [options]
     HELP
 
     o.string "-t", "--team", "the team to create the session under"
@@ -62,7 +62,7 @@ else
       To access this session, please run the following:
 
       ```
-        $ kbsecret new-session -r '#{cmd.opts[:root]}' -u #{users} <label>
+        $ kbsecret new-session <label> -r '#{cmd.opts[:root]}' -u #{users}
       ```
 
       If you don't have KBSecret installed, you can install it from `gem`:

--- a/man/man1/kbsecret-new-session.1.ronnpp
+++ b/man/man1/kbsecret-new-session.1.ronnpp
@@ -3,7 +3,7 @@ kbsecret-new-session(1) - create a new kbsecret(1) session
 
 ## SYNOPSIS
 
-`kbsecret new-session` [options]
+`kbsecret new-session` [options] <label>
 
 ## DESCRIPTION
 
@@ -23,9 +23,6 @@ sessions are ideal for isolating one's own secrets (single-user sessions).
 
 * `-t`, `--team` <team>:
 	Create a team-based session that gets managed by Keybase.
-
-* `-l`, `--label` <label>:
-	The new session's *label*, which identifies it to other `kbsecret` commands.
 
 * `-u`, `--users` <users>:
 	The list of users sharing the session. Users are separated by commas,
@@ -55,9 +52,9 @@ sessions are ideal for isolating one's own secrets (single-user sessions).
 ## EXAMPLES
 
 ```
-	$ kbsecret new-session --team top_secret_company -l beta-api
-	$ kbsecret new-session -l old-keys -r old-keys
-	$ kbsecret new-session -l dev-team -r team -u alice,bob
+	$ kbsecret new-session --team top_secret_company beta-api
+	$ kbsecret new-session -r old-keys old-keys
+	$ kbsecret new-session -r team -u alice,bob dev-team
 ```
 
 ## LINKS

--- a/man/man1/kbsecret-new-session.1.ronnpp
+++ b/man/man1/kbsecret-new-session.1.ronnpp
@@ -3,7 +3,7 @@ kbsecret-new-session(1) - create a new kbsecret(1) session
 
 ## SYNOPSIS
 
-`kbsecret new-session` [options] <label>
+`kbsecret new-session` <label> [options]
 
 ## DESCRIPTION
 
@@ -52,9 +52,9 @@ sessions are ideal for isolating one's own secrets (single-user sessions).
 ## EXAMPLES
 
 ```
-	$ kbsecret new-session --team top_secret_company beta-api
-	$ kbsecret new-session -r old-keys old-keys
-	$ kbsecret new-session -r team -u alice,bob dev-team
+	$ kbsecret new-session beta-api --team top_secret_company
+	$ kbsecret new-session old-keys -r old-keys
+	$ kbsecret new-session dev-team -r team -u alice,bob
 ```
 
 ## LINKS


### PR DESCRIPTION
new-session expects session label passed in explicitly as a command rather than an option

Thank you for contributing to KBSecret! Please fill out the items below to help us merge
your work more quickly.

- [x] Have you run `make test` locally and ensured that all tests pass?
- [x] Have you run `make coverage` locally and ensured that coverage did not drop?

*If* you're changing something in the library:
- [ ] Have you introduced unit tests for your changes?

*If* you're changing something in the CLI:
- [x] Have you updated the manual pages and shell completion (if necessary)?

Please describe your changes briefly here. Thank you!

Resolves #25
