### PR TITLE
test: Add CLI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ test:
 	rake test
 	TEST_NO_KEYBASE=1 rake test
 
+.PHONY: test-cli
+test-cli:
+	bundle exec ruby -I lib:test test/cli/test_all.rb
+
 .PHONY: coverage
 coverage:
 	COVERAGE=1 rake test

--- a/kbsecret.gemspec
+++ b/kbsecret.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ronn", "~> 0.7.3" # make man
   s.add_development_dependency "simplecov", "~> 0" # make coverage
   s.add_development_dependency "yard", "~> 0.9.9" # make doc
+  s.add_development_dependency "aruba", "~> 1.0.0.pre.alpha.2"
 
   # these need to be installed by users and developers alike
   s.add_runtime_dependency "clipboard", "~> 1.1"

--- a/test/cli/test_all.rb
+++ b/test/cli/test_all.rb
@@ -1,0 +1,2 @@
+# NOTE: run the test suite with: $ bundle exec ruby -I lib:test test/cli/test_all.rb -v
+require_relative "test_kbsecret"

--- a/test/cli/test_helper.rb
+++ b/test/cli/test_helper.rb
@@ -1,0 +1,3 @@
+require "aruba/api"
+require "minitest/autorun"
+require "helpers"

--- a/test/cli/test_kbsecret.rb
+++ b/test/cli/test_kbsecret.rb
@@ -1,0 +1,43 @@
+require_relative 'test_helper'
+
+class CLITest < Minitest::Test
+  include Aruba::Api
+  include Helpers
+
+  def setup
+    setup_aruba
+  end
+
+  def test_help
+    run_command_and_stop "kbsecret help"
+    assert_match(/Usage:/, last_command_started.output.chomp)
+  end
+
+  def test_version
+    version_string = "kbsecret version #{KBSecret::VERSION}."
+    run_command_and_stop "kbsecret version"
+    assert_equal version_string, last_command_started.output.chomp
+  end
+
+  def test_commands
+    run_command_and_stop "kbsecret commands"
+  end
+
+  def test_types
+    run_command_and_stop "kbsecret types"
+
+    KBSecret::Record.record_types.each do |type|
+      assert_includes last_command_started.output.chomp, type.to_s
+    end
+  end
+
+  def test_conf
+    # NOTE: assumes availability of bash shell
+    run_command "bash -c 'unset EDITOR && kbsecret conf'"
+    stop_all_commands
+    assert_match(/You need to set \$EDITOR/, last_command_started.stderr.chomp)
+
+    run_command_and_stop "bash -c 'EDITOR=cat && kbsecret conf'"
+    assert_match(/:mount:/, last_command_started.output.chomp)
+  end
+end


### PR DESCRIPTION
Add CLI tests using Aruba and MiniTest. So far, just a POC to see if this approach meshes well with the direction of the project. Open to feedback or redirection before completing the test suite.

Contributes to #7 

- [X] Have you run `make test` locally and ensured that all tests pass?
- [X] Have you run `make coverage` locally and ensured that coverage did not drop?
- [N/A] Have you introduced unit tests for your changes?
- [N/A] Have you updated the manual pages and shell completion (if necessary)?
