### PR TITLE
Remove multiline 'env -n' output

### DIFF
--- a/lib/kbsecret/cli/kbsecret-env
+++ b/lib/kbsecret/cli/kbsecret-env
@@ -37,12 +37,11 @@ selected_records = if cmd.opts.all?
                      end
                    end
 
-selected_records.each do |record|
-  if cmd.opts.value_only?
-    puts record.value
-  elsif cmd.opts.no_export?
-    puts record.to_assignment
-  else
-    puts record.to_export
-  end
-end
+env_output = if cmd.opts.no_export?
+             selected_records.map(&:to_assignment).join(" ")
+           elsif cmd.opts.value_only?
+             selected_records.map(&:value).join("\n")
+           else
+             selected_records.map(&:to_export).join("\n")
+           end
+puts env_output

--- a/man/man1/kbsecret-env.1.ronnpp
+++ b/man/man1/kbsecret-env.1.ronnpp
@@ -25,7 +25,7 @@ loading important environment keys into a program without exposing them directly
 	Print only the value for each environment record, instead of the *export KEY=VALUE* format.
 
 * `-n`, `--no-export`:
-	Print only key/value pairs of the form *KEY=value*, instead of the *export KEY=VALUE* format.
+	Print only key/value pairs of the form *KEY=value*, instead of the *export KEY=VALUE* format. In this mode only, the output is space-delimited rather than newline-delimited.
 
 ## EXAMPLES
 
@@ -42,6 +42,9 @@ loading important environment keys into a program without exposing them directly
 
 	$ kbsecret env -n baz-api
 	BAZ_API=thisapiusesapassword
+
+  $ kbsecret env -n -a
+  BAR_API=0xFEEDFACE BAZ_API=thisapiusesapassword
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
Thank you for contributing to KBSecret! Please fill out the items below to help us merge
your work more quickly.

- [x] Have you run `make test` locally and ensured that all tests pass?
- [x] Have you run `make coverage` locally and ensured that coverage did not drop?

*If* you're changing something in the library:
- [ ] Have you introduced unit tests for your changes?

*If* you're changing something in the CLI:
- [x] Have you updated the manual pages and shell completion (if necessary)?

Please describe your changes briefly here. Thank you!

Closes #28.
Old behaviour:
`-n flag produces multiline $KEY=VAL`
New behaviour:
`-n flag produces space-delimited $KEY=VAL`

Credits to Will for the proposed change :wink: