### PR TITLE
Return error when no login or environment found

### DIFF
--- a/lib/kbsecret/cli/kbsecret-env
+++ b/lib/kbsecret/cli/kbsecret-env
@@ -37,6 +37,8 @@ selected_records = if cmd.opts.all?
                      end
                    end
 
+cmd.die "No such record(s)." if selected_records.empty?
+
 env_output = if cmd.opts.no_export?
              selected_records.map(&:to_assignment).join(" ")
            elsif cmd.opts.value_only?

--- a/lib/kbsecret/cli/kbsecret-login
+++ b/lib/kbsecret/cli/kbsecret-login
@@ -37,6 +37,8 @@ selected_records = if cmd.opts.all?
                      end
                    end
 
+cmd.die "No such record(s)." if selected_records.empty?
+
 selected_records.each do |record|
   if cmd.opts.terse?
     fields = %i[label username password].map { |m| record.send(m) }


### PR DESCRIPTION
Fixes #36

- [X] Have you run `make test` locally and ensured that all tests pass?
- [X] Have you run `make coverage` locally and ensured that coverage did not drop?

*If* you're changing something in the library:
- [ ] Have you introduced unit tests for your changes?

*If* you're changing something in the CLI:
- [ ] Have you updated the manual pages and shell completion (if necessary)?
- [ ] Have you introduced CLI unit tests for your changes and ensured that `make test-cli` passes?

Modify kbsecret-login and kbsecret-env so they return an error when run against a nonexistent record. Tests in progress.