### PR TITLE
more KBFS health checks

### DIFF
--- a/lib/kbsecret.rb
+++ b/lib/kbsecret.rb
@@ -12,7 +12,17 @@ require_relative "kbsecret/cli"
 
 # The primary namespace for {KBSecret}.
 module KBSecret
+  def self.kbfs_logged_in
+    begin
+      return false if JSON.parse(File.read(File.join(Config[:mount], ".kbfs_status")))["CurrentUser"].empty?
+    rescue
+      return false
+    end
+    return true
+  end
   # fail very early if the user doesn't have keybase and KBFS running
   raise Keybase::Local::Exceptions::KeybaseNotRunningError unless Keybase::Local.running?
-  raise Keybase::Local::Exceptions::KBFSNotRunningError unless Dir.exist?(Config[:mount])
+  JSON.parse(File.read(File.join(Config[:mount], ".kbfs_status")))
+  raise Keybase::Local::Exceptions::KBFSNotRunningError unless File.exist?(File.join(Config[:mount], ".kbfs_status"))
+  raise Exceptions::KBSecretError.new("Keybase not logged in") unless self.kbfs_logged_in()
 end


### PR DESCRIPTION
Hey there! Thanks for the awesome project!

We've seen several bug reports where `kbsecret` users had process written into a dir that's supposed to be the KBFS mount point, while it's not mounted. It seems it's because `kbsecret` only checks for existence of `/keybase`, but doesn't make sure it's actually mounted. To mitigate that, this PR checks for `/keybase/.kbfs_status` existence, which is a (hidden) special file that's very unlikely to get written into. In addition (suggested by @strib), check content of `/keybase/.kbfs_status` to make sure user is logged in.

I know close to nothing about ruby, so please bear with me for any stupid mistakes, and feel free to throw it away if there's a more idiomatic/cleaner way to do this!

Thank you for contributing to KBSecret! Please fill out the items below to help us merge
your work more quickly.

- [x] Have you run `make test` locally and ensured that all tests pass?
- [ ] Have you run `make coverage` locally and ensured that coverage did not drop?

*If* you're changing something in the library:
- [ ] Have you introduced unit tests for your changes?

*If* you're changing something in the CLI:
- [ ] Have you updated the manual pages and shell completion (if necessary)?
- [ ] Have you introduced CLI unit tests for your changes and ensured that `make test-cli` passes?

Please describe your changes briefly here. Thank you!
