### PR TITLE
config: Add command aliases

### DIFF
--- a/bin/kbsecret
+++ b/bin/kbsecret
@@ -14,14 +14,14 @@ EXT_CMDS = EXT_PATHS.map do |c|
   File.basename(c, File.extname(c)).sub!("kbsecret-", "")
 end.freeze
 
-ALIASES = Hash.new { |_, k| k }.update(
+FLAGS = Hash.new { |_, k| k }.update(
   "--help" => "help",
   "-h" => "help",
   "--version" => "version",
   "-v" => "version"
 ).freeze
 
-ALL_CMDS = (ALIASES.keys + BUILTIN_CMDS + KBSecret::CLI::Command.command_names + EXT_CMDS).freeze
+ALL_CMDS = (FLAGS.keys + BUILTIN_CMDS + KBSecret::CLI::Command.command_names + EXT_CMDS).freeze
 
 KBSECRET_HELP = <<~KBSECRET_HELP
   Usage:
@@ -55,16 +55,16 @@ def builtin?(cmd)
   BUILTIN_CMDS.include?(cmd)
 end
 
-def alias?(cmd)
-  ALIASES.keys.include?(cmd)
+def flag?(cmd)
+  FLAGS.keys.include?(cmd)
 end
 
 def normalize(cmd)
-  ALIASES[cmd]
+  KBSecret::Config.unalias_command(FLAGS[cmd])
 end
 
 def expand(cmd)
-  return cmd if alias?(cmd) || builtin?(cmd)
+  return cmd if flag?(cmd) || builtin?(cmd)
 
   "kbsecret-#{cmd}"
 end

--- a/lib/kbsecret/config.rb
+++ b/lib/kbsecret/config.rb
@@ -95,6 +95,21 @@ module KBSecret
       @command_config.dig(cmd, "args")&.shellsplit || []
     end
 
+    # Attempt to resolve an alias into a `kbsecret` command.
+    # @param acmd [String] the command alias
+    # @return [String] the `kbsecret` command, or `acmd` if the alias does not exist
+    # @example
+    #  Config.unalias_command("l") # => "list"
+    #  Config.unalias_command("madeup") # => "madeup"
+    def self.unalias_command(acmd)
+      @command_config.each do |cmd, conf|
+        aliases = conf["aliases"]&.split || []
+        return cmd if aliases.include?(acmd)
+      end
+
+      acmd
+    end
+
     # @!method session(label)
     #   Retrieve a session's configuration.
     #   @param label [String, Symbol] the session's label

--- a/man/man5/kbsecret-configuration.5.ronnpp
+++ b/man/man5/kbsecret-configuration.5.ronnpp
@@ -14,7 +14,7 @@ session configuration, and generator configuration. This file is YAML formatted 
 **not** be modified by hand.
 
 * _commands.ini_: Optional. Stores per-command configuration, including default arguments
-for particular commands. This file is INI formatted and can be modified by hand.
+for particular commands and command aliases. This file is INI formatted and can be modified by hand.
 
 As per above, users should **not** modify _kbsecret.yml_ manually. Instead, users
 should use commands like kbsecret-session(1) and kbsecret-generator(1)
@@ -32,9 +32,11 @@ The following is an example of a valid _commands.ini_ file:
 ```
 [list]
 args = --show-all --type login
+aliases = l ls
 
 [new]
 args = --force
+aliases = n
 
 [custom-command]
 args = --frobulate 'bar "quux"'
@@ -50,6 +52,19 @@ regardless of the language used to write subcommand. For example, if the user ra
 ```
 kbsecret list --show-all --type login
 ```
+
+Note also the `aliases` keys, which specify custom names for their respective subcommands. Aliases
+are space-separated. For example, with the given configuration, each of these invocations is
+equivalent:
+
+```
+kbsecret l
+kbsecret ls
+kbsecret list
+```
+
+The precedence of overlapping aliases is **not** guaranteed, which means that you shouldn't
+define overlapping aliases.
 
 Commands may also define additional keys under their sections, as can be seen
 with `customkey` under `custom-command`. KBSecret's `Config` class provides a standard mechanism


### PR DESCRIPTION
This introduces support for command aliases at the configuration
level. Under `commands.ini` (see `kbsecret-configuration(5)`),
commands may define an `aliases` key that provides a list of
valid aliases:

```ini
[list]
aliases = l ls

[rm]
aliases = r remove del delete
```

Users should not declare overlapping aliases, since the order
of resolution is not guaranteed.
